### PR TITLE
Smaller title

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -56,7 +56,7 @@ function getResourceTitle(state: State): string {
     title = selfLink.title;
     href = selfLink.href;
   } else {
-    href = state.uri;
+    href = new URL(state.uri).pathname;
   }
 
   const body = state.data;

--- a/src/components/pager.tsx
+++ b/src/components/pager.tsx
@@ -7,7 +7,7 @@ export function Pager(props: PageProps) {
   const elems = [];
   for (const link of getNavLinks(props.resourceState.links.getAll(), props.options, 'pager')) {
 
-    elems.push(<li>
+    elems.push(<li key={link.rel + '|' + link.href}>
       <a href={link.href} rel={link.rel} title={link.title}>
         <img src={link.icon} /> {link.title}</a>
     </li>);


### PR DESCRIPTION
Using the 'pathname' of the uri as a fallback for the title.
The full request uri can be very large with query parameters.

Bonus: fixed another React warning related to the 'key'

