### PR TITLE
Render forms without fields as single buttons.

### DIFF
--- a/src/components/forms.tsx
+++ b/src/components/forms.tsx
@@ -2,26 +2,38 @@ import * as React from 'react';
 import { PageProps } from '../types';
 import { TemplatedLinks } from './forms/templated-links';
 import { ActionForm } from './forms/ketting-action';
+import { ButtonForm } from './forms/ketting-action-button';
 
 export function Forms(props: PageProps) {
 
   const forms = TemplatedLinks(props);
-  const actions = props.resourceState.actions()
-    .map( action => <ActionForm action={action} csrfToken={props.csrfToken}/>);
-  forms.push(...actions);
+  const buttonForms = [];
 
-  if (!forms.length) {
+  for(const action of props.resourceState.actions()) {
+
+    // Some actions can be expressed as a single button, instaed of a full form.
+    if (action.fields.some( field => field.type !== 'hidden')) {
+      forms.push(<ActionForm action={action} csrfToken={props.csrfToken}/>);
+    } else {
+      buttonForms.push(<ButtonForm action={action} csrfToken={props.csrfToken} />);
+    }
+
+  }
+
+  if (!forms.length && !buttonForms.length) {
     return null;
   }
 
+  /*
   if (Object.keys(props.resourceState.data).length === 0 && forms.length === 1) {
     // If there are 0 data properties, and exactly 1 action we render a page more
     // focused on the single form. We skip the 'forms' header and just the form
     // title instead.
-  }
+  }*/
 
   return <>
     <h2 key="-1">Actions</h2>
+    {buttonForms.map( (form, index) => <span key={index}>{form}</span>)}
     {forms.map( (form, index) => <span key={index}>{form}</span>)}
   </>;
 

--- a/src/components/forms/button.tsx
+++ b/src/components/forms/button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 type Props = {
   method: string;
+  title?: string|null;
 }
 
 const methodLabel: Record<string, string> = {
@@ -14,7 +15,7 @@ const methodLabel: Record<string, string> = {
 
 export function Button(props: Props) {
 
-  const label = methodLabel[props.method] || 'Submit';
+  const label = props.title || methodLabel[props.method] || 'Submit';
   return <button type="submit" className={'method-' + props.method.toLowerCase()}>{label}</button>;
 
 }

--- a/src/components/forms/ketting-action-button.tsx
+++ b/src/components/forms/ketting-action-button.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Action, Field } from 'ketting';
+import { Button } from './button';
+
+type FormProps = {
+  csrfToken: string | null,
+  action: Action
+}
+type FieldProps = {
+  field: Field,
+}
+
+/**
+ * This component renders actions that can be expressed as a single button.
+ *
+ * This is only the case for actions that have no fields or only fields with
+ * type=hidden
+ */
+export function ButtonForm(props: FormProps) {
+
+  const action = props.action;
+  return <form action={action.uri} method={action.method} encType={action.contentType} id={action.name!} className="button-form">
+    {props.csrfToken ? <input type="hidden" name="csrf-token" defaultValue={props.csrfToken} /> : ''}
+    {action.fields.map( field => <ActionField field={field} key={field.name} />) }
+    <Button method={action.method} title={action.title || action.name || null} />
+  </form>;
+
+}
+
+function ActionField(props: FieldProps): React.ReactElement {
+
+  const field = props.field;
+  if (field.type !== 'hidden') {
+    throw new Error('The ActionButtonForm can only render forms that have no fields');
+  }
+
+  return <input
+    name={field.name}
+    type={field.type}
+    defaultValue={field.value?.toString()}
+  />;
+
+}


### PR DESCRIPTION
If there are actions that have 0 fields (or only hidden fields), we can
skip the form header and just render a single button.

The button label is the title of the form.

![Screenshot from 2021-03-26 23-15-42](https://user-images.githubusercontent.com/178960/112708605-412c0600-8e89-11eb-8791-2555d927341f.png)
