### PR TITLE
Handle 201 responses

### DIFF
--- a/src/html-index.tsx
+++ b/src/html-index.tsx
@@ -9,6 +9,7 @@ import { contextToState } from './util';
 export default async function generateHtmlIndex(ctx: Context, options: Options) {
 
   normalizeBody(ctx);
+
   if (!ctx.response.body) {
     return;
   }
@@ -37,11 +38,32 @@ export default async function generateHtmlIndex(ctx: Context, options: Options) 
 
 function normalizeBody(ctx: Context) {
 
+  if (!ctx.response.body && ctx.response.status === 201) {
+
+    // A default response body for 201 respones.
+    ctx.response.body = {
+      title: '201 Created',
+    };
+    if (ctx.response.headers.has('Location')) {
+      ctx.response.body._links = {
+        location: {
+          href: ctx.response.headers.get('Location')
+        }
+      };
+      ctx.response.type = 'application/hal+json';
+    }
+
+  }
   if (ctx.response.body instanceof Buffer || ctx.response.body === null) {
     return;
   }
+
+
   if (typeof ctx.response.body === 'object') {
     ctx.response.body = JSON.stringify(ctx.response.body);
+    return;
   }
+
+
 
 }

--- a/src/html-index.tsx
+++ b/src/html-index.tsx
@@ -46,7 +46,7 @@ function normalizeBody(ctx: Context) {
     };
     if (ctx.response.headers.has('Location')) {
       ctx.response.body._links = {
-        location: {
+        next: {
           href: ctx.response.headers.get('Location')
         }
       };


### PR DESCRIPTION
Fixes #91 

![Screenshot from 2021-10-29 15-49-59](https://user-images.githubusercontent.com/178960/139493829-d31e388f-3e3e-454b-a175-aa656f1c9abe.png)

I had to cheat a bit with the screenshot, because that's what it's supposed to look like. I think we have a bug in how the next/previous links are rendered and it's probably just in the halloween theme.

But the screenshot is the intent
