### PR TITLE
Pick the default theme at runtime.

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -7,10 +7,23 @@ import { Search } from './search';
 import { Navigation } from './navigation';
 import { Alternate } from './alternate';
 import { Resource } from './resource';
+import { getDefaultTheme } from '../util';
 
 export function App(props: PageProps) {
 
-  const stylesheets = props.options.stylesheets.map( ss => {
+  
+  const stylesheetList = [];
+  if (props.options.theme) {
+    const theme = props.options.theme === 'default' ? getDefaultTheme() : props.options.theme;
+    stylesheetList.push(
+      `themes/${theme}/main.css`,
+      `themes/${theme}/highlight.css`
+    );
+  }
+  stylesheetList.push(...props.options.stylesheets);
+
+
+  const stylesheets = stylesheetList.map( ss => {
     const u = url.resolve(props.options.assetBaseUrl, ss);
     return <link rel="stylesheet" href={u} type="text/css" key={u} />;
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,14 +193,9 @@ function normalizeOptions(options?: Partial<Options>): Options {
     options = {};
   }
 
-  const d = new Date();
-  let defaultTheme: Options['theme'] = 'curveball';
-  if (d.getMonth()===9 && d.getDate()>25) defaultTheme = 'halloween';
-  if (d.getMonth()===11 && d.getDate()>14) defaultTheme = 'xmas';
-
   const defaults: Partial<Options> = {
     title: 'API Browser',
-    theme: defaultTheme,
+    theme: 'default',
 
     stylesheets: [],
     defaultLinks: [
@@ -244,14 +239,7 @@ function normalizeOptions(options?: Partial<Options>): Options {
   }
 
   const newOptions:Options = Object.assign(defaults, options) as Options;
-
-  if (newOptions.theme !== null) {
-    newOptions.stylesheets.unshift(
-      `themes/${newOptions.theme}/main.css`,
-      `themes/${newOptions.theme}/highlight.css`
-    );
-  }
-
   return newOptions;
 
 }
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { Link, State } from 'ketting';
 
+type Theme = 'default' | 'spicy-oj' | 'lfo' | 'curveball' | 'xmas' | 'halloween' | null;
+
 /**
  * Options after clean-up.
  *
@@ -16,7 +18,7 @@ export type Options = {
    *
    * Possible options: spicy-oj, lfo, curveball
    */
-  theme: 'spicy-oj' | 'lfo' | 'curveball' | 'xmas' | 'halloween' | null;
+  theme: Theme,
 
   /**
    * List of custom stylesheets to embed.

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,7 @@ import {
   NavigationLink,
   NavigationPosition,
   Options,
+  Theme,
 } from './types';
 import { State, Client } from 'ketting';
 import { Context } from '@curveball/core';
@@ -181,5 +182,20 @@ export function getFieldsFromTemplatedUri(input: string): null | [string, Record
     hiddenFields,
     fields
   ];
+
+}
+
+/**
+ * Returns the default theme
+ *
+ * This might alternate depending on the time of the year.
+ */
+export function getDefaultTheme(): Theme {
+
+  const d = new Date();
+  if (d.getMonth()===9 && d.getDate()>25 || d.getMonth()===1 && d.getDate()<2) return 'halloween';
+  if (d.getMonth()===11 && d.getDate()>14) return 'xmas';
+
+  return 'curveball';
 
 }


### PR DESCRIPTION
Before this change, the holiday themes only kicked in after a server
restart (and will stick until the server has restarted *again*).

This PR makes sure that when halloween hits, the stylesheet changes over
live.