### PR TITLE
New JSON viewer

### DIFF
--- a/assets/themes/curveball/main.css
+++ b/assets/themes/curveball/main.css
@@ -319,3 +319,16 @@ button {
   line-height: 2;
   border-radius: .25ex;
 }
+
+.hljs ul {
+  list-style: none;
+  padding-left: 10px;
+  margin: 0;
+}
+.hljs ul li {
+  padding-left: 10px;
+  margin: 0;
+}
+.hljs a {
+  color: inherit;
+}

--- a/src/components/hal-body.tsx
+++ b/src/components/hal-body.tsx
@@ -5,7 +5,13 @@ import JsonViewer from './json-viewer';
 
 export function HalBody(props: PageProps) {
 
-  const tmpBody = props.resourceState.serializeBody() as string;
+  let tmpBody:string;
+
+  if (props.options.fullBody) {
+    tmpBody = props.resourceState.serializeBody() as string;
+  } else {
+    tmpBody = JSON.stringify(Object.assign({}, props.resourceState.data));
+  }
 
   if (Object.keys(tmpBody).length === 0) {
     return <></>;

--- a/src/components/hal-body.tsx
+++ b/src/components/hal-body.tsx
@@ -1,26 +1,19 @@
 import * as React from 'react';
 import { PageProps } from '../types';
-import { highlightJson } from '../util';
+
+import JsonViewer from './json-viewer';
 
 export function HalBody(props: PageProps) {
 
-  let tmpBody = Object.assign({}, props.resourceState.data);
-
-  if (props.options.fullBody) {
-    tmpBody = JSON.parse(props.resourceState.serializeBody() as string);
-  }
+  const tmpBody = props.resourceState.serializeBody() as string;
 
   if (Object.keys(tmpBody).length === 0) {
     return <></>;
   }
 
-  const html = {
-    __html: highlightJson(tmpBody)
-  };
-
   return <>
     <h2>Contents</h2>
-    <code className="hljs"><pre dangerouslySetInnerHTML={html}></pre></code>
+    <code className="hljs"><JsonViewer data={tmpBody} /></code>
   </>;
 
 }

--- a/src/components/json-viewer.tsx
+++ b/src/components/json-viewer.tsx
@@ -7,14 +7,14 @@ type Props = {
 export default function JsonViewer(props: Props) {
 
   const data = JSON.parse(props.data);
-  return <code className="hljs"><pre>{jsonValueRender(data)}</pre></code>;
+  return <code className="hljs">{renderJsonValue(data)}</code>;
 
 }
 
 type JsonValue = null | string | boolean | number | any[] | Record<string, any>;
 
 
-function jsonValueRender(value: JsonValue, ident = ''): React.ReactNode {
+function renderJsonValue(value: JsonValue, asLink?: boolean): React.ReactNode {
 
   if (value===null) {
     return <span className="hljs-keyword">null</span>;
@@ -23,28 +23,74 @@ function jsonValueRender(value: JsonValue, ident = ''): React.ReactNode {
     return <span className="hljs-keyword">{value?'true':'false'}</span>;
   }
   if (typeof value === 'string') {
-    return <span className="hljs-string">"{value}"</span>;
+    if (asLink && isLegalLink(value)) {
+      return <span className="hljs-string"><a href={value}>"{value}"</a></span>;
+    } else {
+      return <span className="hljs-string">"{value}"</span>;
+    }
   }
   if (typeof value === 'number') {
     return <span className="hljs-number">{value}</span>;
   }
   if (Array.isArray(value)) {
     return <>
-      <span className="hljs-punctuation">[</span>{'\n'}
-      {(value.map((item, idx) => {
-        return <>{ident + '  '}{jsonValueRender(item, ident + '  ')}{idx < value.length -1 ? <span className="hljs-punctuation">,</span>:null}{'\n'}</>;
-      }))}
-      {ident}<span className="hljs-punctuation">]</span>
+      <span className="hljs-punctuation">[</span><ul>
+        {(value.map((item, idx) => {
+          return <li>{renderJsonValue(item)}{idx < value.length -1 ? <span className="hljs-punctuation">,</span>:null}</li>;
+        }))}
+      </ul><span className="hljs-punctuation">]</span>
     </>;
   }
 
-  // Render object
+  return renderJsonObject(value);
+
+}
+
+function renderJsonObject(value: Record<string, JsonValue>) {
+
   return <>
-    <span className="hljs-punctuation">{'{'}</span>{'\n'}
-    {(Object.entries(value).map(([key, value], idx, arr) => {
-      return <>{ident + '  '}<span className="hljs-attr">{key}</span><span className="hljs-punctuation">:</span> {jsonValueRender(value, ident + '  ')}{idx < arr.length -1 ? <span className="hljs-punctuation">,</span>:null}{'\n'}</>;
-    }))}
-    {ident}<span className="hljs-punctuation">{'}'}</span>
+    <span className="hljs-punctuation">{'{'}</span><br />
+    <ul>
+      {(Object.entries(value).map(([key, value], idx, arr) => {
+        return <li>
+          <span className="hljs-attr">{key}</span>
+          <span className="hljs-punctuation">: </span>
+          {renderJsonValue(value, isLikelyAUri(key))}
+          {idx < arr.length -1 ? <span className="hljs-punctuation">,</span>:null}
+        </li>;
+      }))}
+    </ul>
+    <span className="hljs-punctuation">{'}'}</span>
   </>;
+
+}
+
+
+/**
+ * Checks at a name of a property and returns true if it's probably a uri
+ */
+function isLikelyAUri(keyName: string) {
+
+  const key = keyName.toLowerCase();
+  return key.endsWith('href') || key.endsWith('uri') || key.endsWith('url');
+
+}
+
+const allowedSchemes = ['http', 'https', 'mailto', 'gopher'];
+function isLegalLink(uri: string): boolean {
+
+  if (uri.includes('{')) {
+    // Likely a templated URI
+    return false;
+  }
+  if (uri.startsWith('/')) {
+    return true;
+  }
+  for(const scheme of allowedSchemes) {
+    if (uri.startsWith(scheme + ':')) {
+      return true;
+    }
+  }
+  return false;
 
 }

--- a/src/components/json-viewer.tsx
+++ b/src/components/json-viewer.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+type Props = {
+  data: string;
+}
+
+export default function JsonViewer(props: Props) {
+
+  const data = JSON.parse(props.data);
+  return <code className="hljs"><pre>{jsonValueRender(data)}</pre></code>;
+
+}
+
+type JsonValue = null | string | boolean | number | any[] | Record<string, any>;
+
+
+function jsonValueRender(value: JsonValue, ident = ''): React.ReactNode {
+
+  if (value===null) {
+    return <span className="hljs-keyword">null</span>;
+  }
+  if (typeof value === 'boolean') {
+    return <span className="hljs-keyword">{value?'true':'false'}</span>;
+  }
+  if (typeof value === 'string') {
+    return <span className="hljs-string">"{value}"</span>;
+  }
+  if (typeof value === 'number') {
+    return <span className="hljs-number">{value}</span>;
+  }
+  if (Array.isArray(value)) {
+    return <>
+      <span className="hljs-punctuation">[</span>{'\n'}
+      {(value.map((item, idx) => {
+        return <>{ident + '  '}{jsonValueRender(item, ident + '  ')}{idx < value.length -1 ? <span className="hljs-punctuation">,</span>:null}{'\n'}</>;
+      }))}
+      {ident}<span className="hljs-punctuation">]</span>
+    </>;
+  }
+
+  // Render object
+  return <>
+    <span className="hljs-punctuation">{'{'}</span>{'\n'}
+    {(Object.entries(value).map(([key, value], idx, arr) => {
+      return <>{ident + '  '}<span className="hljs-attr">{key}</span><span className="hljs-punctuation">:</span> {jsonValueRender(value, ident + '  ')}{idx < arr.length -1 ? <span className="hljs-punctuation">,</span>:null}{'\n'}</>;
+    }))}
+    {ident}<span className="hljs-punctuation">{'}'}</span>
+  </>;
+
+}


### PR DESCRIPTION
I'm working on a custom JSON viewer for HAL-Browser, instead of relying on HighlightJS.

This PR adds the first version of this, which causes 2 changes:

* We're no longer putting double-quotes around key names, making everything look a bit leaner. (Keeping them for string values)
* Things that look like links are automatically converted to clickable links.

In the future I wanna add more things like letting users expand/collapse part of the tree, a 'raw mode' and maybe even editing JSON, but this is a step in a direction.

**Before**

![before](https://user-images.githubusercontent.com/178960/162116238-0afe3ea2-ecb7-4c76-9e8a-91273588a362.png)

**After**
![Screenshot from 2022-04-06 23-51-07](https://user-images.githubusercontent.com/178960/162116719-2e1a624f-58ae-4e53-9eb2-51195522d1f1.png)


