### PR TITLE
Ugly first attempt at resource metadata

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -53,7 +53,6 @@ export function App(props: PageProps) {
       <main>
         <Resource {...props} />
       </main>
-
     </body>
   </html>;
 

--- a/src/components/resource-metadata.tsx
+++ b/src/components/resource-metadata.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { PageProps } from '../types';
+
+export function ResourceMetaData(props: PageProps) {
+
+  return <>
+    <h2>Resource metadata</h2>
+    <p>Allowed methods:
+      <span className="link-badge method-get">GET</span>
+      <span className="link-badge method-put">PUT</span>
+      <span className="link-badge method-delete">DELETE</span>
+    </p>
+  </>;
+
+}

--- a/src/components/resource.tsx
+++ b/src/components/resource.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
-import { PageProps } from '../types';
+import { Body } from './body';
 import { Embedded } from './embedded';
 import { Forms } from './forms';
 import { LinksTable } from './links-table';
+import { PageProps } from '../types';
 import { Pager } from './pager';
-import { Body } from './body';
+import { ResourceMetaData } from './resource-metadata';
 
 export function Resource(props: PageProps) {
 
@@ -13,8 +14,10 @@ export function Resource(props: PageProps) {
     <LinksTable {...props} />
     <Forms {...props} />
     <Body {...props} />
+    <Pager {...props} />
     <Embedded {...props} />
     <Pager {...props} />
+    <ResourceMetaData {...props} />
   </>;
 
 }


### PR DESCRIPTION
This is in need of a better design idea before I can continue.

For a given resource, I'd like to be able to show some metadata. The source of the metadata are 3 things:

1. `self` link, lots potential hints there.
2. Response headers
3. Response to an `OPTIONS` request.

With that information we can show stuff like:

* Which methods are supported
* Which mime-types are supported (for Accept header, but also patch and post formats)
* The last modification date

This is my first attempt at this:

![Screenshot from 2022-04-07 01-32-30](https://user-images.githubusercontent.com/178960/162127273-6170e277-7892-448a-b771-34b536b84279.png)

It's too cluttered to make this work