### PR TITLE
Auto-generate comments in JSON responses based on json schemas.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE_FILES:=$(shell find src/ -type f -name '*.ts')
+SOURCE_FILES:=$(shell find src/ -type f -name '*.ts' )
 
 .PHONY:all
 all: build

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@curveball/core": "^0.19.0",
+        "@curveball/validator": "^0.9.0",
         "@types/chai": "^4.2.15",
         "@types/markdown-it": "^12.0.1",
         "@types/mocha": "^9.0.0",
@@ -37,6 +38,9 @@
         "nyc": "^15.1.0",
         "ts-node": "^10.0.0",
         "typescript": "^4.2.3"
+      },
+      "engines": {
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@curveball/core": ">=0.14 <1"
@@ -467,6 +471,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@curveball/controller": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@curveball/controller/-/controller-0.3.2.tgz",
+      "integrity": "sha512-Tk/iJWDyGM6tU0OLIRDCVww0z2mvdPeQXxQOFYUz8udD3zVW4kRuHiHeAB0qUNrKicABNflIdh58lMH01B+X1g==",
+      "dev": true,
+      "dependencies": {
+        "@curveball/http-errors": "^0.4.0"
+      }
+    },
     "node_modules/@curveball/core": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.19.0.tgz",
@@ -487,6 +500,20 @@
       "resolved": "https://registry.npmjs.org/@curveball/http-errors/-/http-errors-0.4.1.tgz",
       "integrity": "sha512-RJe0IOQQpgvCwUY8ZKK7/YgfWi1MqMzMrIHilwXHaMFykoVjpRNzaeO3FmrKSUlmJSb6vuPd37LEPNUne4PxZA=="
     },
+    "node_modules/@curveball/links": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@curveball/links/-/links-0.1.6.tgz",
+      "integrity": "sha512-WJc7mzEaqgD/2PwBBX4o6yMQv7i0MIDYb9HG4j4DhLOdYmZB31aC9nTlgCgSjO9ZBk2TZP6OHKws1akoKe4exQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-link-header": "^1.0.2",
+        "hal-types": "^1.2.1",
+        "http-link-header": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@curveball/core": ">=0.16 <1"
+      }
+    },
     "node_modules/@curveball/static": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
@@ -497,6 +524,64 @@
       "peerDependencies": {
         "@curveball/core": ">=0.16 <1"
       }
+    },
+    "node_modules/@curveball/validator": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@curveball/validator/-/validator-0.9.0.tgz",
+      "integrity": "sha512-AmYURoU7C0uZOiVForuxRP+DG6T1uL73YFobuQPMIO7WuTxagv9GkVmbEgedZ5HxSnT4iWtMgCUvN4qoaIZTpg==",
+      "dev": true,
+      "dependencies": {
+        "@curveball/controller": "^0.3.0",
+        "@curveball/http-errors": "^0.4.0",
+        "@curveball/links": "^0.1.5",
+        "@stoplight/better-ajv-errors": "^1.0.1",
+        "ajv": "^8.4.0",
+        "ajv-formats": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@curveball/core": ">=0.16.1 <1"
+      }
+    },
+    "node_modules/@curveball/validator/node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.2.tgz",
+      "integrity": "sha512-7aezVdFKHviyzVSXe8Zjj8tg4bMAxMW/y+rdBhRrN/yBKxg0t0KFqTEZhtJkUAlBaTGvSuc9RG5Ro+tIjOqDnQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@curveball/validator/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@curveball/validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -766,6 +851,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -1156,6 +1250,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -2945,6 +3078,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ketting": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.4.2.tgz",
@@ -2960,6 +3102,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -3904,6 +4055,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5076,6 +5236,15 @@
         }
       }
     },
+    "@curveball/controller": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@curveball/controller/-/controller-0.3.2.tgz",
+      "integrity": "sha512-Tk/iJWDyGM6tU0OLIRDCVww0z2mvdPeQXxQOFYUz8udD3zVW4kRuHiHeAB0qUNrKicABNflIdh58lMH01B+X1g==",
+      "dev": true,
+      "requires": {
+        "@curveball/http-errors": "^0.4.0"
+      }
+    },
     "@curveball/core": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.19.0.tgz",
@@ -5093,12 +5262,67 @@
       "resolved": "https://registry.npmjs.org/@curveball/http-errors/-/http-errors-0.4.1.tgz",
       "integrity": "sha512-RJe0IOQQpgvCwUY8ZKK7/YgfWi1MqMzMrIHilwXHaMFykoVjpRNzaeO3FmrKSUlmJSb6vuPd37LEPNUne4PxZA=="
     },
+    "@curveball/links": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@curveball/links/-/links-0.1.6.tgz",
+      "integrity": "sha512-WJc7mzEaqgD/2PwBBX4o6yMQv7i0MIDYb9HG4j4DhLOdYmZB31aC9nTlgCgSjO9ZBk2TZP6OHKws1akoKe4exQ==",
+      "dev": true,
+      "requires": {
+        "@types/http-link-header": "^1.0.2",
+        "hal-types": "^1.2.1",
+        "http-link-header": "^1.0.3"
+      }
+    },
     "@curveball/static": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
       "integrity": "sha512-6h2P0/CXzOItxHdjGZtpv6yBpshqcLMrejo6vEkEkQR0WCu8BBqNcjD/a7wuy38FYLq0J/QXMidvaFL4jXHh7Q==",
       "requires": {
         "mime-types": "^2.1.29"
+      }
+    },
+    "@curveball/validator": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@curveball/validator/-/validator-0.9.0.tgz",
+      "integrity": "sha512-AmYURoU7C0uZOiVForuxRP+DG6T1uL73YFobuQPMIO7WuTxagv9GkVmbEgedZ5HxSnT4iWtMgCUvN4qoaIZTpg==",
+      "dev": true,
+      "requires": {
+        "@curveball/controller": "^0.3.0",
+        "@curveball/http-errors": "^0.4.0",
+        "@curveball/links": "^0.1.5",
+        "@stoplight/better-ajv-errors": "^1.0.1",
+        "ajv": "^8.4.0",
+        "ajv-formats": "^2.1.0"
+      },
+      "dependencies": {
+        "@stoplight/better-ajv-errors": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.2.tgz",
+          "integrity": "sha512-7aezVdFKHviyzVSXe8Zjj8tg4bMAxMW/y+rdBhRrN/yBKxg0t0KFqTEZhtJkUAlBaTGvSuc9RG5Ro+tIjOqDnQ==",
+          "dev": true,
+          "requires": {
+            "jsonpointer": "^5.0.0",
+            "leven": "^3.1.0"
+          }
+        },
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -5317,6 +5541,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
+    },
+    "@types/http-link-header": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -5589,6 +5822,35 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "ansi-colors": {
@@ -6926,6 +7188,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonpointer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "dev": true
+    },
     "ketting": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.4.2.tgz",
@@ -6939,6 +7207,12 @@
         "sax": "^1.2.4",
         "uri-template": "^2.0.0"
       }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -7655,6 +7929,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/curveball/browser#readme",
   "devDependencies": {
     "@curveball/core": "^0.19.0",
+    "@curveball/validator": "^0.9.0",
     "@types/chai": "^4.2.15",
     "@types/markdown-it": "^12.0.1",
     "@types/mocha": "^9.0.0",

--- a/src/components/embedded.tsx
+++ b/src/components/embedded.tsx
@@ -7,13 +7,20 @@ export function Embedded(props: PageProps) {
   const embeds = props.resourceState.getEmbedded();
   if (!embeds.length) return null;
 
+  const {
+    // The purpose of these two is just to remove them from embeddedProps
+    resourceState,
+    originalBody,
+
+    ...embeddedProps
+  } = props;
+
   return <>
     <h2>Embedded</h2>
     { embeds.map( embeddedState => <Embed
       resourceState={embeddedState}
-      options={props.options}
-      csrfToken={props.csrfToken}
       originalBody={embeddedState.serializeBody() as string}
+      {...embeddedProps}
     />) }
   </>;
 

--- a/src/components/hal-body.tsx
+++ b/src/components/hal-body.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react';
-import { PageProps } from '../types';
+import { PageProps, JsonSchema } from '../types';
 
 import JsonViewer from './json-viewer';
 
 export function HalBody(props: PageProps) {
 
   const body = props.originalBody;
+  let schema: JsonSchema|null = null;
+
+  const describedBy = props.resourceState.links.get('describedby');
+  if (describedBy && describedBy.type === 'application/schema+json') {
+    schema = props.jsonSchemas.get(describedBy.href) ?? null;
+  }
 
   return <>
     <h2>Contents</h2>
-    <code className="hljs"><JsonViewer data={body} /></code>
+    <code className="hljs"><JsonViewer data={body} schema={schema} /></code>
   </>;
 
 }

--- a/src/components/json-viewer.tsx
+++ b/src/components/json-viewer.tsx
@@ -1,20 +1,22 @@
 import * as React from 'react';
+import { JsonSchema } from '../types';
 
 type Props = {
   data: string;
+  schema: JsonSchema | null;
 }
 
 export default function JsonViewer(props: Props) {
 
   const data = JSON.parse(props.data);
-  return <code className="hljs">{renderJsonValue(data)}</code>;
+  return <code className="hljs">{renderJsonValue(data, undefined, props.schema??undefined)}</code>;
 
 }
 
 type JsonValue = null | string | boolean | number | any[] | Record<string, any>;
 
 
-function renderJsonValue(value: JsonValue, asLink?: boolean): React.ReactNode {
+function renderJsonValue(value: JsonValue, asLink?: boolean, schema?: JsonSchema): React.ReactNode {
 
   if (value===null) {
     return <span className="hljs-keyword">null</span>;
@@ -33,20 +35,26 @@ function renderJsonValue(value: JsonValue, asLink?: boolean): React.ReactNode {
     return <span className="hljs-number">{value}</span>;
   }
   if (Array.isArray(value)) {
+
+    let arrayItemSchema:JsonSchema | undefined = undefined;
+    if (schema?.items && !Array.isArray(schema.items)) {
+      arrayItemSchema = schema.items;
+    }
+
     return <>
       <span className="hljs-punctuation">[</span><ul>
         {(value.map((item, idx) => {
-          return <li key={idx}>{renderJsonValue(item)}{idx < value.length -1 ? <span className="hljs-punctuation">,</span>:null}</li>;
+          return <li key={idx}>{renderJsonValue(item, false, arrayItemSchema)}{idx < value.length -1 ? <span className="hljs-punctuation">,</span>:null}</li>;
         }))}
       </ul><span className="hljs-punctuation">]</span>
     </>;
   }
 
-  return renderJsonObject(value);
+  return renderJsonObject(value, false, schema);
 
 }
 
-function renderJsonObject(value: Record<string, JsonValue>, skipOpen = false) {
+function renderJsonObject(value: Record<string, JsonValue>, skipOpen = false, jsonSchema?: JsonSchema) {
 
   return <>
     {skipOpen ? null : <><span className="hljs-punctuation">{'{'}</span><br /></>}
@@ -55,7 +63,8 @@ function renderJsonObject(value: Record<string, JsonValue>, skipOpen = false) {
         return renderCollapsableRow(
           key,
           value,
-          idx >= arr.length -1
+          idx >= arr.length -1,
+          jsonSchema?.properties?.[key],
         );
       }))}
     </ul>
@@ -64,7 +73,9 @@ function renderJsonObject(value: Record<string, JsonValue>, skipOpen = false) {
 
 }
 
-function renderCollapsableRow(key: string, value: JsonValue, isLast: boolean): React.ReactNode {
+function renderCollapsableRow(key: string, value: JsonValue, isLast: boolean, jsonSchema?: JsonSchema): React.ReactNode {
+
+  const description = jsonSchema?.description ? <li key={key + '-desc'}><span className="hljs-comment">{'// ' + jsonSchema.description}</span></li> : undefined;
 
   if (isJsonObject(value)) {
 
@@ -72,28 +83,34 @@ function renderCollapsableRow(key: string, value: JsonValue, isLast: boolean): R
     // This ensures that stuff like _links, _embedded starts closed
     const open = !key.startsWith('_');
 
-    return <li key={key}><details open={open}>
-      <summary>
+    return <React.Fragment key={key}>
+      {description}
+      <li key={key}><details open={open}>
+        <summary>
+          <span className="hidden-copy-paste">"</span>
+          <span className="hljs-attr">{key}</span>
+          <span className="hidden-copy-paste">"</span>
+          <span className="hljs-punctuation">: {'{'}</span>
+          <span className="hidden-when-open">
+            <span className="hljs-punctuation"> <em>{Object.keys(value).length} properties</em> {'}'}</span>
+          </span>
+        </summary>
+        {renderJsonObject(value, true)}
+        {isLast ? null : <span className="hljs-punctuation">,</span>}
+      </details></li>
+    </React.Fragment>;
+  } else {
+    return <React.Fragment key={key}>
+      {description}
+      <li key={key}>
         <span className="hidden-copy-paste">"</span>
         <span className="hljs-attr">{key}</span>
         <span className="hidden-copy-paste">"</span>
-        <span className="hljs-punctuation">: {'{'}</span>
-        <span className="hidden-when-open">
-          <span className="hljs-punctuation"> <em>{Object.keys(value).length} properties</em> {'}'}</span>
-        </span>
-      </summary>
-      {renderJsonObject(value, true)}
-      {isLast ? null : <span className="hljs-punctuation">,</span>}
-    </details></li>;
-  } else {
-    return <li key={key}>
-      <span className="hidden-copy-paste">"</span>
-      <span className="hljs-attr">{key}</span>
-      <span className="hidden-copy-paste">"</span>
-      <span className="hljs-punctuation">: </span>
-      {renderJsonValue(value, isLikelyAUri(key))}
-      {isLast ? null : <span className="hljs-punctuation">,</span>}
-    </li>;
+        <span className="hljs-punctuation">: </span>
+        {renderJsonValue(value, isLikelyAUri(key))}
+        {isLast ? null : <span className="hljs-punctuation">,</span>}
+      </li>
+    </React.Fragment>;
   }
 
 }

--- a/src/html-index.tsx
+++ b/src/html-index.tsx
@@ -1,10 +1,12 @@
 import { Context } from '@curveball/core';
-import { Options } from './types';
+import { Options, JsonSchema } from './types';
 import * as ReactDOMServer from 'react-dom/server';
 import * as React from 'react';
 
 import { App } from './components/app';
 import { contextToState } from './util';
+
+import '@curveball/validator';
 
 export default async function generateHtmlIndex(ctx: Context, options: Options) {
 
@@ -30,9 +32,23 @@ export default async function generateHtmlIndex(ctx: Context, options: Options) 
     csrfToken = await (ctx as any).getCsrf();
   }
 
+  const jsonSchemas = new Map<string, JsonSchema>();
+
+  if (ctx.schemas) {
+    for(const schema of ctx.schemas) {
+      jsonSchemas.set(schema.id, schema.schema);
+    }
+  }
+
   ctx.response.type = 'text/html; charset=utf-8';
   ctx.response.body = ReactDOMServer.renderToString(
-    <App resourceState={state} options={options} csrfToken={csrfToken} originalBody={ctx.response.body}/>
+    <App
+      resourceState={state}
+      options={options}
+      csrfToken={csrfToken}
+      originalBody={ctx.response.body}
+      jsonSchemas={jsonSchemas}
+    />
   );
 
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,4 +132,15 @@ export type PageProps = {
   originalBody: string;
   options: Options;
   csrfToken: string | null;
+  jsonSchemas: Map<string, JsonSchema>;
+}
+
+/**
+ * A very basic type for json schema. It's just barely enough.
+ */
+export type JsonSchema = {
+  '$id'?: string;
+  description?: string;
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema | JsonSchema[];
 }


### PR DESCRIPTION
When a user is using the [validator](https://github.com/curveball/validator) plugin, and a response has a `describedby` link set to a JSON Schema ID, the browser plugin will read the JSON Schema, find 'description' properties and insert descriptions into the JSON viewer.

![Screenshot 2022-06-16 at 21-58-41 Evert - a12n-server](https://user-images.githubusercontent.com/178960/174207314-2f06351a-9f09-490b-a706-1ce8d95c87e7.png)
