### PR TITLE
Update ketting to the latest version #142

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@curveball/static": "^0.2.0",
         "csv-parse": "^5.1.0",
         "highlight.js": "^11.2.0",
-        "ketting": "^7.3.0",
+        "ketting": "^7.5.0",
         "markdown-it": "^13.0.1",
         "node-fetch": "^2.6.7",
         "react": "^18.1.0",
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/ketting": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.4.2.tgz",
-      "integrity": "sha512-1I+sHkBasVmbsEu5PDMWYarBN7qtbygvylLGnRxGvjUTb448nhFAdZeNsa35p70QdSwoqdD7OYzJfpokVmDKJQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.5.0.tgz",
+      "integrity": "sha512-N2YqmqDE4h020Oc3iHUwi8TPOkz7fvMcVeC4wXDZVNGp5mQoWoCYUs76WfS4SF2uQNjRZWQxT6eAv1/5gqnJTA==",
       "dependencies": {
         "fetch-mw-oauth2": "^1.0.0",
         "hal-types": "^1.7.7",
@@ -7211,9 +7211,9 @@
       "dev": true
     },
     "ketting": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.4.2.tgz",
-      "integrity": "sha512-1I+sHkBasVmbsEu5PDMWYarBN7qtbygvylLGnRxGvjUTb448nhFAdZeNsa35p70QdSwoqdD7OYzJfpokVmDKJQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/ketting/-/ketting-7.5.0.tgz",
+      "integrity": "sha512-N2YqmqDE4h020Oc3iHUwi8TPOkz7fvMcVeC4wXDZVNGp5mQoWoCYUs76WfS4SF2uQNjRZWQxT6eAv1/5gqnJTA==",
       "requires": {
         "fetch-mw-oauth2": "^1.0.0",
         "hal-types": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@curveball/static": "^0.2.0",
     "csv-parse": "^5.1.0",
     "highlight.js": "^11.2.0",
-    "ketting": "^7.3.0",
+    "ketting": "^7.5.0",
     "markdown-it": "^13.0.1",
     "node-fetch": "^2.6.7",
     "react": "^18.1.0",


### PR DESCRIPTION
Resolves #142 

## Changes
- upgraded ketting dependency from 7.3.0 to 7.5.0. 

### Testing
- tested most of the a12n and media-api routes to see if anything broke 
- tested this issue again https://github.com/curveball/a12n-server/issues/420 and it was resolved