### PR TITLE
Comments are not appearing #141

### DIFF
--- a/src/components/json-viewer.tsx
+++ b/src/components/json-viewer.tsx
@@ -95,7 +95,7 @@ function renderCollapsableRow(key: string, value: JsonValue, isLast: boolean, js
             <span className="hljs-punctuation"> <em>{Object.keys(value).length} properties</em> {'}'}</span>
           </span>
         </summary>
-        {renderJsonObject(value, true)}
+        {renderJsonObject(value, true, jsonSchema)}
         {isLast ? null : <span className="hljs-punctuation">,</span>}
       </details></li>
     </React.Fragment>;
@@ -107,7 +107,7 @@ function renderCollapsableRow(key: string, value: JsonValue, isLast: boolean, js
         <span className="hljs-attr">{key}</span>
         <span className="hidden-copy-paste">"</span>
         <span className="hljs-punctuation">: </span>
-        {renderJsonValue(value, isLikelyAUri(key))}
+        {renderJsonValue(value, isLikelyAUri(key), jsonSchema)}
         {isLast ? null : <span className="hljs-punctuation">,</span>}
       </li>
     </React.Fragment>;


### PR DESCRIPTION
Resolves #141 

## Changes

the JSONschema was not being passed back into `renderJsonObject` and `renderJsonValue`

### Example of it working
![Screen Shot 2022-09-06 at 9 37 52 AM](https://user-images.githubusercontent.com/31973147/188651076-4955bd05-ab5b-40fe-b0da-0783be5dbd2d.png)

## Note

In the screenshot, audienceRetention is an array of objects. Comments for these are not appearing and has more context here: https://github.com/curveball/browser/issues/149
