### PR TITLE
Fix the datetime-local value

### DIFF
--- a/src/components/forms/ketting-action.tsx
+++ b/src/components/forms/ketting-action.tsx
@@ -83,7 +83,7 @@ export function ActionField(props: FieldProps): React.ReactElement {
     case 'week' : {
       let value;
       if (field.value instanceof Date) {
-        value = field.value.toISOString();
+        value = field.value.toISOString().slice(0, -1);
       } else {
         value = field.value?.toString();
       }


### PR DESCRIPTION
The value that goes into the `datetime-local` field shouldn't have a timezone. This strips off the `Z` that gets added to the end.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local#value
> There are several methods provided by JavaScript's [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) that can be used to convert numeric date information into a properly-formatted string. For example, the [Date.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) method returns the date/time in UTC with the suffix "Z" denoting that timezone; removing the "Z" would provide a value in the format expected by a datetime-local input.

Would it be possible to also backport this to `v0.18.0`? I'd like to be able to delivery this fix without needing to update everything to require `@curveball/kernel`